### PR TITLE
記事内に表示する画像の大きさを調整

### DIFF
--- a/client/src/app/components/article/article.component.scss
+++ b/client/src/app/components/article/article.component.scss
@@ -19,3 +19,12 @@
   margin-left: 5%;
   text-align: left;
 }
+
+/deep/ .content {
+  img {
+      max-width: 95%;
+      height: auto;
+      overflow: hidden;
+      margin-bottom: 30px;
+  }
+}


### PR DESCRIPTION
## 必要な理由
* 画像が大きすぎるとレイアウトが崩れるため

## 対応内容
### フロントエンドの変更
* 記事内の画像にmax-widthを設定

### サーバサイドの変更
* 

## その他（確認したいことがあれば）
* 

